### PR TITLE
G-code lastCommand remember only G00 through G03

### DIFF
--- a/cnc_ctrl_v1/CNC_Functions.h
+++ b/cnc_ctrl_v1/CNC_Functions.h
@@ -1248,25 +1248,20 @@ void  executeGcodeLine(const String& gcodeLine){
    
     int gNumber = extractGcodeValue(gcodeLine,'G', -1);
     
-    if (gNumber != -1){                                     //If the line has a valid G number
-        lastCommand = gNumber;                              //remember it for next time
-    }
-    else{                                                   //If the line does not have a gcommand
-        gNumber = lastCommand;                              //apply the last one
+    if (gNumber == -1){               // If the line does not have a G command
+        gNumber = lastCommand;        // apply the last one
     }
     
     switch(gNumber){
-        case 0:
+        case 0:   // Rapid positioning
+        case 1:   // Linear interpolation
             G1(gcodeLine, gNumber);
+            lastCommand = gNumber;    // remember G number for next time
             break;
-        case 1:
-            G1(gcodeLine, gNumber);
-            break;
-        case 2:
+        case 2:   // Circular interpolation, clockwise
+        case 3:   // Circular interpolation, counterclockwise
             G2(gcodeLine, gNumber);
-            break;
-        case 3:
-            G2(gcodeLine, gNumber);
+            lastCommand = gNumber;    // remember G number for next time
             break;
         case 10:
             G10(gcodeLine);


### PR DESCRIPTION
Fix G-code lastCommand to remember only G00 through G03 for when future lines omit the G number. (It doesn't make sense to remember other G numbers as they are not movement commands.)

Also combined cases for G00 and G01, since both use G1(), and G02 and G03, since both use G2()..